### PR TITLE
Added global nets and prefix style, fixed text update

### DIFF
--- a/config.py.template
+++ b/config.py.template
@@ -5,6 +5,10 @@ main_pcb_file = 'example/1-PCB_Main.json'
 out_sch_file = 'example/output_sch.json'
 out_pcb_file = 'example/output_pcb.json'
 
+# Use 1 for default suffix with underscore and channel name (e.g. R1_CH1)
+# Use 2 to append channel name in front with a colon (e.g. CH1:R1)
+channel_prefix_style = 1
+
 channel_sources = [
 	(
 		'example/1-Schematic_example_channel.json',		# sch file


### PR DESCRIPTION
Adding the channel name in front of the component or net name can be useful for people who are used to working with modules in Eagle.

The global nets feature is useful when using lots of modules (or channels) that have a number of nets in common, for instance address lines, data lines and clock lines. (In my current use case I have a clock line which is used by all channels and a shared return line using a diode-OR gate)

Lastly, removing the (assumed) line drawing data for the component prefix labels seems to force EasyEDA to recreate it (at least on my version v6.3.43). I have not tested this on other versions yet.